### PR TITLE
 Add installation alternatives in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ python3 -m pip install --upgrade pip setuptools
 python3 -m pip install norminette
 ```
 
+Install using pipx.
+```shell
+sudo apt update
+sudo apt install pipx
+pipx install norminette
+pipx ensurepath
+```
+
+Install using a virtual environment.
+```shell
+python3 -m venv $HOME/.venv
+source $HOME/.venv/bin/activate
+python3 -m pip install --upgrade pip setuptools
+python3 -m pip install norminette
+echo "export PATH=\$PATH:$HOME/.venv/bin" >> $HOME/.${SHELL##/bin/}rc
+deactivate
+```
+
 To upgrade an existing install, use
 ```shell
 python3 -m pip install --upgrade norminette

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ python3 -m pip install norminette
 Install using pipx.
 ```shell
 sudo apt update
+sudo apt install python3-setuptools
 sudo apt install pipx
 pipx install norminette
 pipx ensurepath


### PR DESCRIPTION
# Description

To solve [Issue #485](https://github.com/42School/norminette/issues/485) I included alternatives to install Norminette.

## Problem

The commands mentioned in README might lead to an error due to PEP 668.

![Screenshot of the issue](https://github.com/SrVariable/norminette/assets/96599624/6b87e08e-5532-416b-a980-3949bfd228c9)

## Solution

I added a couple alternatives to install Norminette.
- Using pipx
- Using a virtual environment